### PR TITLE
tcp-tunnel: botch Linux support

### DIFF
--- a/tcp-tunnel/Makefile
+++ b/tcp-tunnel/Makefile
@@ -10,6 +10,7 @@ src := $(wildcard src/*.c) $(wildcard src/**/*.c)
 
 CC = clang
 FLAGS = -DOUT_OF_TREE_BUILD -I$(QEMU_DIR)/include -fno-stack-check -fno-stack-protector -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+# FLAGS += -DLINUX
 TARGET = tunnel
 
 bin/$(TARGET): $(src)


### PR DESCRIPTION
See for context:
https://github.com/alephsecurity/xnu-qemu-arm64/pull/23

For some reason, EAGAIN (`35`) is changed on Darwin, causing a headache when the host sends its EAGAIN (`11`).