### PR TITLE
Allow optional IOS SDK override for building on OSX without Xcode installed.

### DIFF
--- a/tcp-tunnel/Makefile
+++ b/tcp-tunnel/Makefile
@@ -7,6 +7,8 @@ $(error QEMU_DIR is not set)
 endif
 
 ifndef SDK_DIR
+# git clone https://github.com/xybp888/iOS-SDKs.git
+# export SDK_DIR=$PWD/iOS-SDKs/iPhoneOS12.4.sdk
 SDK_DIR = '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk'
 endif
 

--- a/tcp-tunnel/Makefile
+++ b/tcp-tunnel/Makefile
@@ -6,10 +6,14 @@ ifndef QEMU_DIR
 $(error QEMU_DIR is not set)
 endif
 
+ifndef SDK_DIR
+SDK_DIR = '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk'
+endif
+
 src := $(wildcard src/*.c) $(wildcard src/**/*.c)
 
 CC = clang
-FLAGS = -DOUT_OF_TREE_BUILD -I$(QEMU_DIR)/include -fno-stack-check -fno-stack-protector -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+FLAGS = -DOUT_OF_TREE_BUILD -I$(QEMU_DIR)/include -fno-stack-check -fno-stack-protector -arch arm64 -isysroot $(SDK_DIR)
 TARGET = tunnel
 
 bin/$(TARGET): $(src)


### PR DESCRIPTION
Allows a fresh OSX box to build the tcp-tunnel without Xcode SDKs, which are currently hardcoded into the Makefile

```
git clone https://github.com/xybp888/iOS-SDKs.git
export SDK_DIR=$PWD/iOS-SDKs/iPhoneOS12.4.sdk
```